### PR TITLE
IT-496: Updating with auto-semver workflow

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,17 @@
+---
+name: Enforce Labeling
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Pull Request Labels
+        uses: discoverygarden/enforce-label@v1
+        with:
+          required_labels: major,minor,patch,no-update

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,17 @@
+name: Auto Semver
+on:
+  pull_request_target:
+    types: closed
+    branches:
+      - main
+jobs:
+  update:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Auto Semver
+        uses: discoverygarden/auto-semver@v1
+      - name: Update Major Tag
+        uses: discoverygarden/action-major-tag@v1
+        with:
+          prefix: 'v'


### PR DESCRIPTION
Normally, we wouldn't tag this with a `Major`, `Minor`, or `Patch` tags, and instead with `no-update`, but tags were not made on a previous update, so we want to add the workflows to automatically make the tags, and then generate the tags in the same moment.